### PR TITLE
fix: CI/CD 빌드 실패 해결 - 콘솔 로그 제거 및 테스트 텍스트 수정

### DIFF
--- a/src/components/01_accordion/Accordion.test.tsx
+++ b/src/components/01_accordion/Accordion.test.tsx
@@ -161,7 +161,7 @@ describe('AccordionCollection', () => {
     render(<AccordionCollection />);
     expect(screen.getByText('아코디언 컴포넌트 모음')).toBeInTheDocument();
     expect(
-      screen.getByText('vanilla-extract + CVA로 구현한 8가지 아코디언 예시들')
+      screen.getByText('8가지 다른 방식으로 구현한 아코디언 예시들입니다.')
     ).toBeInTheDocument();
   });
 
@@ -173,9 +173,9 @@ describe('AccordionCollection', () => {
       screen.getByText('🎯 조건부 렌더링 (Conditional Rendering)')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('📚 vanilla-extract + CVA 장점')
+      screen.getByText('vanilla-extract + CVA를 사용하는 이유')
     ).toBeInTheDocument();
-    expect(screen.getByText('🔍 8가지 구현 방식 비교')).toBeInTheDocument();
+    expect(screen.getByText('8가지 구현 방식 비교')).toBeInTheDocument();
   });
 
   it('displays implementation summary', () => {
@@ -184,7 +184,7 @@ describe('AccordionCollection', () => {
     // Check for key benefits
     expect(screen.getByText('타입 안전성:')).toBeInTheDocument();
     expect(screen.getByText('성능:')).toBeInTheDocument();
-    expect(screen.getByText('유지보수성:')).toBeInTheDocument();
+    expect(screen.getByText('유지보수:')).toBeInTheDocument();
   });
 
   it('displays implementation comparison', () => {

--- a/src/components/02_tabMenu/3_animated.tsx
+++ b/src/components/02_tabMenu/3_animated.tsx
@@ -50,7 +50,6 @@ const TabMenuAnimated = () => {
   const [isInitialized, setIsInitialized] = useState(false);
 
   // 초기 활성 탭 확인
-  console.log('Initial activeId:', activeId);
 
   const isActive = (id: string) => id === activeId;
 
@@ -73,26 +72,21 @@ const TabMenuAnimated = () => {
     const timeoutId = setTimeout(() => {
       // 현재 활성 탭의 인덱스 찾기
       const activeIndex = tabData.findIndex(tab => tab.id === activeId);
-      console.log('Active index:', activeIndex, 'Active ID:', activeId);
 
       if (activeIndex === -1) {
-        console.log('Active tab not found in data:', activeId);
         return;
       }
 
       // 모든 탭 요소 가져오기
       const allTabs = document.querySelectorAll('[data-tab-id]');
-      console.log('Found tabs:', allTabs.length);
 
       if (allTabs.length === 0) {
-        console.log('No tabs found with data-tab-id');
         return;
       }
 
       const activeTab = allTabs[activeIndex] as HTMLElement;
 
       if (!activeTab) {
-        console.log('Active tab element not found at index:', activeIndex);
         return;
       }
 
@@ -103,13 +97,6 @@ const TabMenuAnimated = () => {
       if (containerRect) {
         const left = tabRect.left - containerRect.left;
         const width = tabRect.width;
-
-        console.log('Indicator position:', {
-          left,
-          width,
-          activeId,
-          activeIndex,
-        });
 
         indicator.style.transform = `translateX(${left}px)`;
         indicator.style.width = `${width}px`;

--- a/src/components/02_tabMenu/index.tsx
+++ b/src/components/02_tabMenu/index.tsx
@@ -23,10 +23,7 @@ const TabMenuCollection = () => {
       {/* 기본 탭메뉴 컴포넌트 */}
       <div className={styles.section}>
         <h3 className={styles.sectionTitle}>기본 탭메뉴 컴포넌트</h3>
-        <TabMenu
-          data={tabData}
-          onTabChange={id => console.log('탭 변경:', id)}
-        />
+        <TabMenu data={tabData} onTabChange={id => {}} />
       </div>
 
       {/* 다양한 구현 방식들 */}


### PR DESCRIPTION
## 📝 변경사항
- TabMenuAnimated 컴포넌트의 console.log 제거
- 아코디언 테스트 텍스트를 실제 페이지와 일치하도록 수정
- "유지보수성:" → "유지보수:" 테스트 기대값 업데이트
- CI/CD 파이프라인을 위한 테스트 출력 정리
